### PR TITLE
added pointer-events: none

### DIFF
--- a/src/centriamTable/table.scss
+++ b/src/centriamTable/table.scss
@@ -67,6 +67,7 @@ $stripe-color: #FBFBFB;
         &:after{
           font-size: 2em;
           position:relative;
+          pointer-events: none;
           right: 1.2em;
           top:.2em;
           color: #53585B;


### PR DESCRIPTION
Without this property, the select drop down doesn't open when you click the arrow